### PR TITLE
bump up debug package version to fix npm audit warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "accepts": "1.3.5",
     "batch": "0.6.1",
     "@gerhobbelt/pretty-bytes": "5.1.1-2",
-    "debug": "4.0.1",
+    "debug": "4.3.4",
     "escape-html": "1.0.3",
     "http-errors": "1.7.1",
     "mime-types": "2.1.20",


### PR DESCRIPTION
See https://github.com/advisories/GHSA-gxpj-cx7g-858c for Regular Expression Denial of Service in debug.